### PR TITLE
Adding alternative title for logo in header.html

### DIFF
--- a/material/partials/header.html
+++ b/material/partials/header.html
@@ -6,9 +6,9 @@
           {% if config.theme.logo.icon %}
             <i class="md-icon">{{ config.theme.logo.icon }}</i>
           {% elif config.theme.logo.startswith("http") %}
-            <img src="{{ config.theme.logo }}" width="24" height="24">
+            <img src="{{ config.theme.logo }}" alt="Link to homepage with theme's logo" width="24" height="24">
           {% else %}
-            <img src="{{ base_url }}/{{ config.theme.logo }}" width="24" height="24">
+            <img src="{{ base_url }}/{{ config.theme.logo }}" alt="Link to homepage with theme's logo" width="24" height="24">
           {% endif %}
         </a>
       </div>


### PR DESCRIPTION
Hello dear maintainer!

This pull request introduces the following change: adding an alternative title for the logo's image in the header.

The "alt" is explaining the intent since this is a link to the homepage with an image as link's content.

Ref. https://www.w3schools.com/tags/att_img_alt.asp 

> Guidelines for the alt text:
> ...
> The text should explain where the link goes if the image is inside an <a> element
> ...


=> The initial goal is to have a valid HTML when using mkdocs with material them, against w3c compliancy which raise an error.